### PR TITLE
referencing the ENV['KINESIS_PARTITION_KEY'] directly.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,14 @@
 # docker-fluentd-s3
 
 this command will route all containers outputs to a kinesis stream:
+```
 	docker run --name logger -d \
 		-e AWS_KEY=key \
 		-e AWS_SECRET=secret \
 		-e KINESIS_STREAM_NAME=stream1 \
 		-e KINESIS_PARTITION_KEY=pkey \
-		-e KINESIS_REGISION=us-east-1 \
+		-e KINESIS_REGION=us-east-1 \
 		-v /var/lib/docker/containers:/var/lib/docker/containers \
 		-v /var/log/docker:/var/log/docker \
 		tmuskal/fluentd-kinesis
+```

--- a/fluent.conf
+++ b/fluent.conf
@@ -20,5 +20,5 @@
   aws_sec_key "#{ENV['AWS_SECRET']}"
   region "#{ENV['KINESIS_REGION']}"
 
-  partition_key_expr record[ENV['KINESIS_PARTITION_KEY']]
+  partition_key_expr "#{ENV['KINESIS_PARTITION_KEY']}"
 </match>


### PR DESCRIPTION
Hi,
Nice work. I apologize if I misunderstood the usage, but I needed to reference the KINESIS_PARTITION_KEY directly in order for this to work.  Am I missing something?
Thanks,
-Nelson
